### PR TITLE
Stop upstream timeout errors being propagated as 404s

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -110,6 +110,10 @@ class BaseHandler(tornado.web.RequestHandler):
                     # Return a Bad Gateway status if the error came from upstream
                     self._error(502)
                     return
+                elif result.loader_error == LoaderResult.ERROR_TIMEOUT:
+                    # Return a Gateway Timeout status if upstream timed out (i.e. 599)
+                    self._error(504)
+                    return
                 else:
                     self._error(500)
                     return

--- a/thumbor/loaders/__init__.py
+++ b/thumbor/loaders/__init__.py
@@ -13,6 +13,7 @@ class LoaderResult(object):
 
     ERROR_NOT_FOUND = 'not_found'
     ERROR_UPSTREAM = 'upstream'
+    ERROR_TIMEOUT = 'timeout'
 
     def __init__(self, buffer=None, successful=True, error=None, metadata=dict()):
         '''

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -46,7 +46,11 @@ def return_contents(response, url, callback, context):
     context.metrics.incr('original_image.status.' + str(response.code))
     if response.error:
         result.successful = False
-        result.error = LoaderResult.ERROR_NOT_FOUND
+        if response.code == 599:
+            # Return a Gateway Timeout status downstream if upstream times out
+            result.error = LoaderResult.ERROR_TIMEOUT
+        else:
+            result.error = LoaderResult.ERROR_NOT_FOUND
 
         logger.warn("ERROR retrieving image {0}: {1}".format(url, str(response.error)))
 


### PR DESCRIPTION
This passes on 599s as 504s, because 404s get cached by our CDN layer.

We receive `599 Timeout` errors from our image downloading, and if we pass them up as 404s, then they get cached. We'd rather pass them on as `504 Gateway Timeout` responses, which can be handled specifically.

https://github.com/thumbor/thumbor/issues/529