### PR TITLE
this should do it

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -232,6 +232,12 @@ class BaseEngine(object):
         return round(float(new_width) * height / width, 0)
 
     def _get_exif_segment(self):
+        if (self.context.config.RESPECT_ORIENTATION is False):
+            return None
+
+        if (hasattr(self, 'exif')):
+            logger.info('Processing exif data: %s', self.exif)
+
         if (not hasattr(self, 'exif')) or self.exif is None:
             return None
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -134,6 +134,9 @@ class BaseHandler(tornado.web.RequestHandler):
         This function is called after the PRE_LOAD filters have been applied.
         It applies the AFTER_LOAD filters on the result, then crops the image.
         """
+
+        logger.info('Loading image for request: %s', self.context.request.url)
+
         try:
             result = yield self._fetch(
                 self.context.request.image_url


### PR DESCRIPTION
So, we actually didn't have orientation enabled so this shouldn't even be running to begin with. Why it was is a bit of a mystery. But this short circuits EXIF retrieval/parsing if `RESPECT_ORIENTATION` isn't set to true. In our case, it's set to false. Which I didn't realize was true but it is. 

I've test this with the wackest EXIF data and of course, no memory explosion. Image is returned perfectly.